### PR TITLE
check for undefined by comparing against void 0

### DIFF
--- a/isa.js
+++ b/isa.js
@@ -44,15 +44,6 @@
    */
 
   /**
-   * type checking for `undefined`
-   *
-   * @static
-   * @method undefined
-   * @param {Object} o given input
-   * @return {boolean} true if given input is a `undefined`
-   */
-
-  /**
    * type checking for `function`
    *
    * @static
@@ -60,7 +51,7 @@
    * @param {Object} o given input
    * @return {boolean} true if given input is a `function`
    */
-  ['string', 'boolean', 'undefined', 'function'].forEach(function(p) {
+  ['string', 'boolean', 'function'].forEach(function(p) {
     isa[p] = function(o) {
       this.name = p;
       return p === typeof o;
@@ -68,6 +59,18 @@
   });
 
   isa.bool = isa.boolean;
+  
+  /**
+   * type checking for `undefined`
+   *
+   * @static
+   * @method undefined
+   * @param {Object} o given input
+   * @return {boolean} true if given input is a `undefined`
+   */
+  isa.undefined = function(o) {
+    return void 0 === o;
+  }
 
   /**
    * type checking for `null`


### PR DESCRIPTION
Apparently undefined [could be overwritten](http://stackoverflow.com/questions/7452341/what-does-void-0-mean) in old browsers, so `typeof undefined` might not be `'undefined'`. Checking against `void 0` would be better for backwards compatibility.

It's a really quick change, so I thought I'd just write it. Feel free to merge it or not! Backwards compatibility with old browsers might not be top priority for most use cases of this module, but I feel it'd be nice to have.